### PR TITLE
natter2 multiple fixes

### DIFF
--- a/luci-app-natter2/Makefile
+++ b/luci-app-natter2/Makefile
@@ -8,7 +8,7 @@ PKG_RELEASE:=3
 
 LUCI_TITLE:=LuCI Support for Natter v2.0.0-rc2
 LUCI_PKGARCH:=all
-LUCI_DEPENDS:=+natter2
+LUCI_DEPENDS:=+natter2 +coreutils-nohup
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/luci-app-natter2/Makefile
+++ b/luci-app-natter2/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-natter2
 PKG_VERSION:=1.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 LUCI_TITLE:=LuCI Support for Natter v2.0.0-rc2
 LUCI_PKGARCH:=all

--- a/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
+++ b/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
@@ -1,8 +1,8 @@
 m = Map("natter2", translate("Instances Settings"),
-translate("")
-.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/usage.md">]]
-.. translate("Instructions")
-.. [[</a>]])
+	translate("")
+	.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/usage.md">]]
+	.. translate("Instructions")
+	.. [[</a>]])
 m.redirect = luci.dispatcher.build_url("admin", "network", "natter2")
 
 s = m:section(NamedSection, arg[1], "instances", "")
@@ -40,6 +40,8 @@ keepalive_server:depends({enable_keepalive_server = "1"})
 interval = s:option(Value, "interval", translate("Interval (Seconds)"), translate("The number of seconds between keepalive"))
 interval.default = 15
 interval.datatype = "uinteger"
+enable_upnp_service = s:option(Flag, "enable_upnp_service", translate("Enable UPnP Service"),
+	translate("Using UPnP to map ports on your device"))
 
 enable_bonding = s:option(Flag, "enable_bonding", translate("Enable Bonding Options"), translate("Usually there is no need to enable binding"))
 enable_bonding.rmempty = true
@@ -56,10 +58,10 @@ bonding_port:depends({enable_bonding = "1"})
 enable_forwarding = s:option(Flag, "enable_forwarding", translate("Enable Forwarding Options"), translate("Forwarding to internal devices"))
 
 forwarding_method = s:option(ListValue, "forwarding_method", translate("Forwarding Method"),
-translate("")
-.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/forward.md">]]
-.. translate("Instructions for forwarding method")
-.. [[</a>]])
+	translate("")
+	.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/forward.md">]]
+	.. translate("Instructions for forwarding method")
+	.. [[</a>]])
 forwarding_method:value('socket', translate("socket (Not Recommended)"))
 if check_binary("iptables") then
 	forwarding_method:value('iptables', translate("iptables (Recommended)"))
@@ -79,9 +81,9 @@ forwarding_method:depends({enable_forwarding = "1"})
 target_address = s:option(Value, "target_address", translate("Target Address"))
 target_address.datatype = "ipmask4"
 luci.sys.net.ipv4_hints(
-function(ip, name)
+	function(ip, name)
 	target_address:value(ip, "%s (%s)" %{ ip, name })
-end)
+	end)
 target_address:depends({enable_forwarding = "1"})
 
 target_port = s:option(Value, "target_port", translate("Target Port"))
@@ -108,10 +110,10 @@ log_level:value('verbose', translate("Verbose"))
 enable_notify = s:option(Flag,"enable_notify", translate("Enable Notify Script"))
 enable_notify.rmempty = false
 notify_path = s:option(Value, "notify_path", translate("Notify Script Path"),
-translate("")
-.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/script.md">]]
-.. translate("Instructions for using the notification script")
-.. [[</a>]])
+	translate("")
+	.. [[<a href="https://github.com/MikeWang000000/Natter/blob/master/docs/script.md">]]
+	.. translate("Instructions for using the notification script")
+	.. [[</a>]])
 notify_path.rmempty = true
 notify_path.default = "/usr/share/luci-app-natter2/notify-example.sh"
 notify_path:depends({enable_notify = "1"})

--- a/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
+++ b/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
@@ -43,17 +43,17 @@ interval.datatype = "uinteger"
 enable_upnp_service = s:option(Flag, "enable_upnp_service", translate("Enable UPnP Service"),
 	translate("Using UPnP to map ports on your device"))
 
-enable_bonding = s:option(Flag, "enable_bonding", translate("Enable Bonding Options"), translate("Usually there is no need to enable binding"))
-enable_bonding.rmempty = true
-bonding_interface = s:option(Value, "bonding_interface", translate("Bonding Interface"))
-bonding_interface.rmempty = true
-bonding_interface.default = '0.0.0.0'
-bonding_interface:depends({enable_bonding = "1"})
+enable_binding = s:option(Flag, "enable_binding", translate("Enable Binding Options"), translate("Usually there is no need to enable binding"))
+enable_binding.rmempty = true
+binding_interface = s:option(Value, "binding_interface", translate("Binding Interface"))
+binding_interface.rmempty = true
+binding_interface.default = '0.0.0.0'
+binding_interface:depends({enable_binding = "1"})
 
-bonding_port = s:option(Value, "bonding_port", translate("Bonding Port"))
-bonding_port.rmempty = true
-bonding_port.default = '0'
-bonding_port:depends({enable_bonding = "1"})
+binding_port = s:option(Value, "binding_port", translate("Binding Port"))
+binding_port.rmempty = true
+binding_port.default = '0'
+binding_port:depends({enable_binding = "1"})
 
 enable_forwarding = s:option(Flag, "enable_forwarding", translate("Enable Forwarding Options"), translate("Forwarding to internal devices"))
 

--- a/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
+++ b/luci-app-natter2/luasrc/model/cbi/natter2/instances.lua
@@ -64,7 +64,7 @@ forwarding_method:value('socket', translate("socket (Not Recommended)"))
 if check_binary("iptables") then
 	forwarding_method:value('iptables', translate("iptables (Recommended)"))
 end
-if check_binary("nftables") then
+if check_binary("nft") then
 	forwarding_method:value('nftables', translate("nftables (Recommended)"))
 end
 if check_binary("socat") then

--- a/luci-app-natter2/po/zh-cn/natter2.po
+++ b/luci-app-natter2/po/zh-cn/natter2.po
@@ -64,13 +64,13 @@ msgstr "保活间隔（秒）"
 msgid "The number of seconds between keepalive"
 msgstr "每次保活的间隔秒数"
 
-msgid "Enable Bonding Options"
+msgid "Enable Binding Options"
 msgstr "启用绑定"
 
-msgid "Bonding Interface"
+msgid "Binding Interface"
 msgstr "绑定接口"
 
-msgid "Bonding Port"
+msgid "Binding Port"
 msgstr "绑定端口"
 
 msgid "Enable Forwarding Options"

--- a/luci-app-natter2/po/zh-cn/natter2.po
+++ b/luci-app-natter2/po/zh-cn/natter2.po
@@ -147,3 +147,9 @@ msgstr "提示"
 
 msgid "After clicking Exec button, please wait for the luci to refresh"
 msgstr "点击执行后，请耐心等待页面自动刷新"
+
+msgid "Enable UPnP Service"
+msgstr "启用 UPnP 服务"
+
+msgid "Enable UPnP Service"
+msgstr "使用 UPnP 映射设备上的端口"

--- a/luci-app-natter2/po/zh_Hans/natter2.po
+++ b/luci-app-natter2/po/zh_Hans/natter2.po
@@ -64,13 +64,13 @@ msgstr "保活间隔（秒）"
 msgid "The number of seconds between keepalive"
 msgstr "每次保活的间隔秒数"
 
-msgid "Enable Bonding Options"
+msgid "Enable Binding Options"
 msgstr "启用绑定"
 
-msgid "Bonding Interface"
+msgid "Binding Interface"
 msgstr "绑定接口"
 
-msgid "Bonding Port"
+msgid "Binding Port"
 msgstr "绑定端口"
 
 msgid "Enable Forwarding Options"

--- a/luci-app-natter2/po/zh_Hans/natter2.po
+++ b/luci-app-natter2/po/zh_Hans/natter2.po
@@ -147,3 +147,9 @@ msgstr "提示"
 
 msgid "After clicking Exec button, please wait for the luci to refresh"
 msgstr "点击执行后，请耐心等待页面自动刷新"
+
+msgid "Enable UPnP Service"
+msgstr "启用 UPnP 服务"
+
+msgid "Enable UPnP Service"
+msgstr "使用 UPnP 映射设备上的端口"

--- a/luci-app-natter2/root/etc/init.d/natter2
+++ b/luci-app-natter2/root/etc/init.d/natter2
@@ -98,9 +98,9 @@ start_service() {
 
 stop_service() {
 	echo "Stopping Natter2 ..."
-	for i in $(ps -efww | grep "$script_path" | grep -v grep | grep -v $$ | awk '{print $1}')
+	for i in $(ps -ww | grep "$script_path" | grep -v grep | grep -v $$ | awk '{print $1}')
 	do
-		kill -9 "$i" 2> /dev/null
+		kill -15 "$i" 2> /dev/null
 	done
 	rm -r "$tmp_path" 2> /dev/null
 	for u in $(seq 0 $(($(uci show natter2 2> /dev/null | egrep '@instances\[[0-9]\]+=instances' | wc -l) - 1)))
@@ -109,6 +109,7 @@ stop_service() {
 		uci commit natter2
 	done
 	rm -f /tmp/natter2_nat_type
+	
 }
 
 restart() {

--- a/luci-app-natter2/root/etc/init.d/natter2
+++ b/luci-app-natter2/root/etc/init.d/natter2
@@ -10,7 +10,7 @@ start_service() {
 		interval enable_bonding bonding_interface bonding_port \
 		enable_forwarding forwarding_method target_address target_port \
 		enable_forwarding_retry enable_quit delay log_level enable_notify \
-		notify_path"
+		notify_path enable_upnp_service"
 	for i in $basic_list
 	do
 		local eval $i="$(uci_get_by_type base 0 $i)"
@@ -43,6 +43,8 @@ start_service() {
 			[ "$enable_keepalive_server" == 1 ] && script_command="$script_command -h $keepalive_server"
 			[ "$interval" ] && script_command="$script_command -k $interval"
 			
+			[ "$enable_upnp_service" == 1 ] && script_command="$script_command -U"
+
 			if [ "$enable_bonding" == 1 ]
 			then
 				[ "$bonding_interface" ] && script_command="$script_command -i $bonding_interface"


### PR DESCRIPTION
- added nohup dependency
- added nftables support (app looks for the wrong binary file)
- ps on busybox do not support '-f' and '-e' params, so stop service logic never worked on openwrt 24.10
- current stop_service logic prevents natter.py to run cleanup functions, changed it to SIGTERM [here](https://github.com/MikeWang000000/Natter/blob/ce1427650178167d2330c490d2e5cd979223e9a4/natter.py#L1939)